### PR TITLE
Definir códigos de error una sola vez.

### DIFF
--- a/zoort.py
+++ b/zoort.py
@@ -188,7 +188,7 @@ def backup_database(args):
     if not database:
         raise SystemExit(_error_codes.get(01))
     if path and not os.path.isdir(path):
-        raise SystemExit(_error_codes.get(06))
+        raise SystemExit(_error_codes.get(05))
 
     query = 'mongodump -d {database} --host {host} '
     if username:


### PR DESCRIPTION
Dado que estan definidos codigos de error, en mi opinion sería más, fácil definirlos todos de una vez en un solo lugar y llamarlos según
sea el caso.
