### PR TITLE
Fix

### DIFF
--- a/zoort.py
+++ b/zoort.py
@@ -273,15 +273,6 @@ def factory_uploader(type_uploader, *args, **kwargs):
             self.path = normalize_path(kwargs.get('path',
                                        config_data.get('ftp').get('path')))
 
-            self.host = kwargs.get('host',
-                                   config_data.get('ftp').get('host'))
-            self.user = kwargs.get('user',
-                                   config_data.get('ftp').get('user'))
-            self.passwd = kwargs.get('passwd',
-                                     config_data.get('ftp').get('passwd'))
-            self.path = normalize_path(kwargs.get('path',
-                                       config_data.get('ftp').get('path')))
-
             self.name_backup = kwargs.get('name_backup', None)
 
             if not self.name_backup:

--- a/zoort.py
+++ b/zoort.py
@@ -342,7 +342,7 @@ def factory_uploader(type_uploader, *args, **kwargs):
             Change to 'path' directory or create if not exist
             '''
             try:
-                self.conn.cwd(self.folder)
+                self.conn.cwd(path)
             except:
                 self.change_dir('/')
                 for folder in path.split('/'):


### PR DESCRIPTION
Quité la parte repetida en en el método init de la clase FTP.
Cambié la variable self.folder por path como estaba antes porque sino siempre iría al mismo lugar (aparte que no existe esa variable).

Pensé que eran cambios que habían quedado por la mitad pero como no se volvió a tocar decidí arreglarlo.  Si me adelanté a algo me avisan. Así tambien mando la parte de eliminar los archivos viejos de dropbox y descargar los archivos por ftp.
